### PR TITLE
[MITSemSeg] Return color map and label information with semseg module 

### DIFF
--- a/lwp_model_zoo/common.py
+++ b/lwp_model_zoo/common.py
@@ -9,6 +9,12 @@ def get_torchhub_dir(
 
     normalized_br = repo_branch.replace("/", "_")
     return os.path.join(
-        hub.get_dir(), "_".join([repo_owner, lwp_repo_name, normalized_br,]),
+        hub.get_dir(),
+        "_".join(
+            [
+                repo_owner,
+                lwp_repo_name,
+                normalized_br,
+            ]
+        ),
     )
-

--- a/lwp_model_zoo/semantic_segmentation/lwp_mit_semseg.py
+++ b/lwp_model_zoo/semantic_segmentation/lwp_mit_semseg.py
@@ -189,7 +189,9 @@ def mit_semseg(model_name="", use_cuda=True, **kwargs):
     )
 
     encoder = ModelBuilder.build_encoder(
-        arch=cfg.MODEL.arch_encoder, fc_dim=cfg.MODEL.fc_dim, weights=encoder_path,
+        arch=cfg.MODEL.arch_encoder,
+        fc_dim=cfg.MODEL.fc_dim,
+        weights=encoder_path,
     )
     crit = nn.NLLLoss(ignore_index=-1)
     seg_module = SegmentationModule(encoder, decoder, crit)

--- a/lwp_model_zoo/semantic_segmentation/lwp_mit_semseg.py
+++ b/lwp_model_zoo/semantic_segmentation/lwp_mit_semseg.py
@@ -197,4 +197,4 @@ def mit_semseg(model_name="", use_cuda=True, **kwargs):
     if use_cuda:
         seg_module.cuda()
 
-    return seg_module
+    return seg_module, model.get_color_map(), model.get_labels()

--- a/lwp_model_zoo/semantic_segmentation/lwp_mit_semseg_config.py
+++ b/lwp_model_zoo/semantic_segmentation/lwp_mit_semseg_config.py
@@ -5,9 +5,9 @@ GH_CONTENT_URL: Final[str] = "https://raw.githubusercontent.com/"
 
 class Config:
     BASE_URL: Final[str] = "http://sceneparsing.csail.mit.edu/model/pytorch/"
-    GH_BASE_URL: Final[
-        str
-    ] = GH_CONTENT_URL + "CSAILVision/semantic-segmentation-pytorch/master/"
+    GH_BASE_URL: Final[str] = (
+        GH_CONTENT_URL + "CSAILVision/semantic-segmentation-pytorch/master/"
+    )
     DECODER_FMT: Final[str] = "{}_decoder_epoch_{}.pth"
     ENCODER_FMT: Final[str] = "{}_encoder_epoch_{}.pth"
     CFG_URL_FMT: Final[str] = GH_BASE_URL + "config/{}.yaml"
@@ -20,13 +20,21 @@ class Config:
             20,
             "ade20k-mobilenetv2dilated-c1_deepsup",
         ),
-        ("ade20k-resnet18dilated-c1_deepsup", 20, None,),
+        (
+            "ade20k-resnet18dilated-c1_deepsup",
+            20,
+            None,
+        ),
         (
             "ade20k-resnet18dilated-ppm_deepsup",
             20,
             "ade20k-resnet18dilated-ppm_deepsup",
         ),
-        ("ade20k-resnet50-upernet", 30, "ade20k-resnet50-upernet",),
+        (
+            "ade20k-resnet50-upernet",
+            30,
+            "ade20k-resnet50-upernet",
+        ),
         (
             "ade20k-resnet50dilated-ppm_deepsup",
             20,


### PR DESCRIPTION
This patch fixes a bug that is related to the omitted return objects such as color map and label.

Signed-off-by: Wook Song <wook16.song@samsung.com>